### PR TITLE
fix: multiple small fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ install_dev:
 	pip3 install -r ./requirements_dev.txt
 
 lint:
-	black --check src/ tests/
-	isort --check-only src/ tests/
-	flake8 src/ tests/
+	black --check chainbase_sdk/ tests/
+	isort --check-only chainbase_sdk/ tests/
+	flake8 chainbase_sdk/ tests/
 
 format:
-	black src/ tests/
-	isort src/ tests/
-	flake8 src/ tests/
+	black chainbase_sdk/ tests/
+	isort chainbase_sdk/ tests/
+	flake8 chainbase_sdk/ tests/
 
 test:
 	pytest -v

--- a/chainbase_sdk/sql_alpha.py
+++ b/chainbase_sdk/sql_alpha.py
@@ -15,6 +15,7 @@ MAP_TYPES = {
     "TIMESTAMP": "datetime64[ns]",
     "DATETIME": "datetime64[ns]",
     "INT": "object",
+    "CHAR": "object",
 }
 
 

--- a/chainbase_sdk/sql_alpha.py
+++ b/chainbase_sdk/sql_alpha.py
@@ -9,12 +9,12 @@ MAP_TYPES = {
     "bigint": "int64",
     "varchar": "object",
     "timestamp": "datetime64[ns]",
-    "integer": "object",
+    "integer": "int64",
     "BIGINT": "int64",
     "VARCHAR": "object",
     "TIMESTAMP": "datetime64[ns]",
     "DATETIME": "datetime64[ns]",
-    "INT": "object",
+    "INT": "int64",
     "CHAR": "object",
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chainbase_sdk"
-dynamic = ["version", "description", "license", "dependencies"]
+dynamic = ["version", "description", "license", "dependencies", "authors"]
 
 [build-system]
 requires = ["setuptools>=42", "wheel"]
@@ -15,7 +15,7 @@ profile = "black"
 [tool.pytest.ini_options]
 addopts = """
 --cov-report term-missing \
---cov src -ra"""
+--cov chainbase_sdk -ra"""
 
 [tool.coverage.report]
 fail_under=90

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     description="A Python SDK for interacting with Chainbase APIs.",
     author="Panos",
     url="https://github.com/ppsimatikas/chainbase_python_sdk",
-    packages=find_packages(exclude=["tests"]),
+    packages=find_packages(include=["chainbase_sdk"], exclude=["tests"]),
     install_requires=[
         "requests==2.32.3",
         "pandas==2.1.3"

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -7,7 +7,7 @@ from pandas.testing import assert_frame_equal
 from chainbase_sdk.sql import ChainbaseSQL
 
 
-@patch("src.sql.ChainbaseAPI.post")
+@patch("chainbase_sdk.sql.ChainbaseAPI.post")
 class TestSQL(unittest.TestCase):
     def setUp(self):
         self.url = "https://api.chainbase.online/v1/dw/query"


### PR DESCRIPTION
there are a number of type castings which are new and need to be added to the mapping. these were causing trouble and making the extraction have multiple multiple commas otherwise

there were also some old references to the src folder which needed rewriting
